### PR TITLE
Port the Card component

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -5,7 +5,7 @@ import { Button, View } from '../../baseElements';
 import { SubcomponentPropsType } from '../commonTypes';
 import { FoundryContextType, useTheme } from '../../context';
 
-import { remToPx } from '../../utils/styles';
+import { remToPx, getShadowStyle } from '../../utils/styles';
 
 import FeedbackTypes from '../../enums/feedbackTypes';
 
@@ -28,6 +28,7 @@ export const CardContainer = styled(Button)`
       font-size: ${remToPx(1, scale)}px;
       border-radius: ${remToPx(0.25, scale)}px;
       border: ${!elevation ? `1px solid ${colors.grayXlight}` : '0px solid transparent'};
+      ${getShadowStyle(elevation, colors.shadow)};
       background-color: ${colors.background};
   `;
   }}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,4 +1,6 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
+import { Rect, PressableAndroidRippleConfig, LayoutChangeEvent } from 'react-native';
+
 import styled, { StyledComponentBase } from 'styled-components';
 
 import { Button, View } from '../../baseElements';
@@ -8,6 +10,7 @@ import { FoundryContextType, useTheme } from '../../context';
 import { remToPx, getShadowStyle } from '../../utils/styles';
 
 import FeedbackTypes from '../../enums/feedbackTypes';
+import colors from '../../enums/colors';
 
 const defaultOnPress = () => {};
 
@@ -107,6 +110,8 @@ export interface CardProps {
   footer?: ReactNode;
 
   elevation?: number;
+  hitSlop?: Rect | number;
+  android_ripple?: PressableAndroidRippleConfig;
   disableFeedback?: boolean;
   feedbackType?: FeedbackTypes;
 
@@ -144,6 +149,8 @@ const Card = ({
   footer,
 
   elevation = 1,
+  hitSlop = 6,
+  android_ripple,
   feedbackType = FeedbackTypes.ripple,
 }: CardProps): JSX.Element | null => {
   const hasHeader = Boolean(header);
@@ -152,12 +159,30 @@ const Card = ({
 
   const theme = useTheme();
 
+  const [rippleRadius, setRippleRadius] = useState(100);
+
+  const handleLayoutChange = (event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+
+    setRippleRadius(Math.max(width, height) / 2);
+  };
+
+  const rippleConfig = {
+    color: colors.grayDark25,
+    radius: rippleRadius,
+    borderLess: false,
+    ...android_ripple,
+  };
+
   return (
     <StyledContainer
       onPress={onPress}
+      onLayout={handleLayoutChange}
       elevation={elevation}
       feedbackType={feedbackType}
       theme={theme}
+      android_ripple={rippleConfig}
+      hitSlop={hitSlop}
       {...containerProps}
       ref={containerRef}
     >

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -3,7 +3,7 @@ import { Rect, PressableAndroidRippleConfig, LayoutChangeEvent } from 'react-nat
 
 import styled, { StyledComponentBase } from 'styled-components';
 
-import { Button, View } from '../../baseElements';
+import { Button, Text, View } from '../../baseElements';
 import { SubcomponentPropsType } from '../commonTypes';
 import { FoundryContextType, useTheme } from '../../context';
 
@@ -37,7 +37,7 @@ export const CardContainer = styled(Button)`
 
 export const Header = styled(View)`
   ${({ hasBody, hasFooter, theme }) => {
-    const { colors, scale } = theme;
+    const { scale } = theme;
 
     return `
       padding: ${remToPx(1.5, scale)}px ${remToPx(1.5, scale)}px ${
@@ -47,9 +47,18 @@ export const Header = styled(View)`
       border-top-right-radius: ${remToPx(0.25, scale)}px;
       border-bottom-right-radius: ${remToPx(0, scale)}px;
       border-bottom-left-radius: ${remToPx(0, scale)}px;
-      font-weight: bold;
-      color: ${colors.grayDark};
     `;
+  }}
+`;
+
+export const HeaderText = styled(Text)`
+  ${({ theme }) => {
+    const { colors } = theme;
+
+    return `
+    font-weight: bold;
+    color: ${colors.grayDark};
+  `;
   }}
 `;
 
@@ -60,18 +69,23 @@ export const NoPaddingHeader = styled(Header)`
 
 export const Body = styled(View)`
   ${({ theme }) => {
-    const { colors, scale } = theme;
+    const { scale } = theme;
 
-    return `
-      padding: ${remToPx(1.5, scale)}px ${remToPx(1.5, scale)}px;
-      color: ${colors.grayMedium};
-    `;
+    return `padding: ${remToPx(1.5, scale)}px ${remToPx(1.5, scale)}px;`;
+  }}
+`;
+
+export const BodyText = styled(Text)`
+  ${({ theme }) => {
+    const { colors } = theme;
+
+    return `color: ${colors.grayMedium};`;
   }}
 `;
 
 export const Footer = styled(View)`
   ${({ theme }) => {
-    const { colors, scale } = theme;
+    const { scale } = theme;
 
     return `
       padding: ${remToPx(1, scale)}px ${remToPx(1.5, scale)}px;
@@ -80,13 +94,19 @@ export const Footer = styled(View)`
 
       justify-content: flex-end;
 
-      color: ${colors.grayLight};
-
       border-top-left-radius: ${remToPx(0, scale)}px;
       border-top-right-radius: ${remToPx(0, scale)}px;
       border-bottom-right-radius: ${remToPx(0.25, scale)}px;
       border-bottom-left-radius: ${remToPx(0.25, scale)}px;
     `;
+  }}
+`;
+
+export const FooterText = styled(Text)`
+  ${({ theme }) => {
+    const { colors } = theme;
+
+    return `color: ${colors.grayLight};`;
   }}
 `;
 
@@ -187,7 +207,7 @@ const Card = ({
           theme={theme}
           {...headerProps}
         >
-          {header}
+          {typeof header === 'string' ? <HeaderText theme={theme}>{header}</HeaderText> : header}
         </StyledHeader>
       )}
       {children && (
@@ -198,7 +218,7 @@ const Card = ({
           theme={theme}
           {...bodyProps}
         >
-          {children}
+          {typeof children === 'string' ? <BodyText theme={theme}>{children}</BodyText> : children}
         </StyledBody>
       )}
       {footer && (
@@ -209,7 +229,7 @@ const Card = ({
           theme={theme}
           {...footerProps}
         >
-          {footer}
+          {typeof footer === 'string' ? <FooterText theme={theme}>{footer}</FooterText> : footer}
         </StyledFooter>
       )}
     </StyledContainer>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -188,6 +188,10 @@ const Card = ({
     ...android_ripple,
   };
 
+  if (typeof hitSlop === 'number') {
+    hitSlop = { x: hitSlop, y: hitSlop };
+  }
+
   return (
     <StyledContainer
       onPress={onPress}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -136,9 +136,6 @@ export interface CardProps {
   headerRef?: React.RefObject<HTMLDivElement>;
   bodyRef?: React.RefObject<HTMLDivElement>;
   footerRef?: React.RefObject<HTMLDivElement>;
-  interactiveFeedbackRef?: React.RefObject<HTMLDivElement>;
-
-  theme: FoundryContextType;
 }
 
 const Card = ({

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -9,20 +9,18 @@ import { FoundryContextType, useTheme } from '../../context';
 
 import { remToPx, getShadowStyle } from '../../utils/styles';
 
-import FeedbackTypes from '../../enums/feedbackTypes';
 import colors from '../../enums/colors';
 
 const defaultOnPress = () => {};
 
 export type CardContainerProps = {
   elevation: number;
-  feedbackType: FeedbackTypes;
   onPress: (...args: any[]) => void;
   theme: FoundryContextType;
 };
 
 export const CardContainer = styled(Button)`
-  ${({ elevation, feedbackType, onPress, theme }: CardContainerProps) => {
+  ${({ elevation, theme }: CardContainerProps) => {
     const { colors, scale } = theme;
 
     return `
@@ -113,7 +111,6 @@ export interface CardProps {
   hitSlop?: Rect | number;
   android_ripple?: PressableAndroidRippleConfig;
   disableFeedback?: boolean;
-  feedbackType?: FeedbackTypes;
 
   containerRef?: React.RefObject<HTMLDivElement>;
   headerRef?: React.RefObject<HTMLDivElement>;
@@ -134,13 +131,11 @@ const Card = ({
   headerProps,
   bodyProps,
   footerProps,
-  interactionFeedbackProps,
 
   containerRef,
   headerRef,
   bodyRef,
   footerRef,
-  interactiveFeedbackRef,
 
   onPress = defaultOnPress,
 
@@ -151,7 +146,6 @@ const Card = ({
   elevation = 1,
   hitSlop = 6,
   android_ripple,
-  feedbackType = FeedbackTypes.ripple,
 }: CardProps): JSX.Element | null => {
   const hasHeader = Boolean(header);
   const hasBody = Boolean(children);
@@ -179,7 +173,6 @@ const Card = ({
       onPress={onPress}
       onLayout={handleLayoutChange}
       elevation={elevation}
-      feedbackType={feedbackType}
       theme={theme}
       android_ripple={rippleConfig}
       hitSlop={hitSlop}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,0 +1,206 @@
+import React, { ReactNode } from 'react';
+import styled, { StyledComponentBase } from 'styled-components';
+
+import { Button, View } from '../../baseElements';
+import { SubcomponentPropsType } from '../commonTypes';
+import { FoundryContextType, useTheme } from '../../context';
+
+import { remToPx } from '../../utils/styles';
+
+import FeedbackTypes from '../../enums/feedbackTypes';
+
+const defaultOnPress = () => {};
+
+export type CardContainerProps = {
+  elevation: number;
+  feedbackType: FeedbackTypes;
+  onPress: (...args: any[]) => void;
+  theme: FoundryContextType;
+};
+
+export const CardContainer = styled(Button)`
+  ${({ elevation, feedbackType, onPress, theme }: CardContainerProps) => {
+    const { colors, scale } = theme;
+
+    return `
+      display: flex;
+      flex-flow: column nowrap;
+      font-size: ${remToPx(1, scale)}px;
+      border-radius: ${remToPx(0.25, scale)}px;
+      border: ${!elevation ? `1px solid ${colors.grayXlight}` : '0px solid transparent'};
+      background-color: ${colors.background};
+  `;
+  }}
+`;
+
+export const Header = styled(View)`
+  ${({ hasBody, hasFooter, theme }) => {
+    const { colors, scale } = theme;
+
+    return `
+      padding: ${remToPx(1.5, scale)}px ${remToPx(1.5, scale)}px ${
+      hasBody || hasFooter ? `${remToPx(0, scale)}px` : ''
+    };
+      border-top-left-radius: ${remToPx(0.25, scale)}px;
+      border-top-right-radius: ${remToPx(0.25, scale)}px;
+      border-bottom-right-radius: ${remToPx(0, scale)}px;
+      border-bottom-left-radius: ${remToPx(0, scale)}px;
+      font-weight: bold;
+      color: ${colors.grayDark};
+    `;
+  }}
+`;
+
+export const NoPaddingHeader = styled(Header)`
+  padding: 0;
+  overflow: hidden;
+`;
+
+export const Body = styled(View)`
+  ${({ theme }) => {
+    const { colors, scale } = theme;
+
+    return `
+      padding: ${remToPx(1.5, scale)}px ${remToPx(1.5, scale)}px;
+      color: ${colors.grayMedium};
+    `;
+  }}
+`;
+
+export const Footer = styled(View)`
+  ${({ theme }) => {
+    const { colors, scale } = theme;
+
+    return `
+      padding: ${remToPx(1, scale)}px ${remToPx(1.5, scale)}px;
+      display: flex;
+      flex-flow: row wrap;
+
+      justify-content: flex-end;
+
+      color: ${colors.grayLight};
+
+      border-top-left-radius: ${remToPx(0, scale)}px;
+      border-top-right-radius: ${remToPx(0, scale)}px;
+      border-bottom-right-radius: ${remToPx(0.25, scale)}px;
+      border-bottom-left-radius: ${remToPx(0.25, scale)}px;
+    `;
+  }}
+`;
+
+export interface CardProps {
+  StyledContainer?: string & StyledComponentBase<any, {}>;
+  StyledHeader?: string & StyledComponentBase<any, {}>;
+  StyledBody?: string & StyledComponentBase<any, {}>;
+  StyledFooter?: string & StyledComponentBase<any, {}>;
+
+  containerProps?: SubcomponentPropsType;
+  headerProps?: SubcomponentPropsType;
+  bodyProps?: SubcomponentPropsType;
+  footerProps?: SubcomponentPropsType;
+
+  onPress?: (...args: any[]) => void;
+
+  header?: ReactNode;
+  children?: ReactNode;
+  footer?: ReactNode;
+
+  elevation?: number;
+  disableFeedback?: boolean;
+  feedbackType?: FeedbackTypes;
+
+  containerRef?: React.RefObject<HTMLDivElement>;
+  headerRef?: React.RefObject<HTMLDivElement>;
+  bodyRef?: React.RefObject<HTMLDivElement>;
+  footerRef?: React.RefObject<HTMLDivElement>;
+  interactiveFeedbackRef?: React.RefObject<HTMLDivElement>;
+
+  theme: FoundryContextType;
+}
+
+const Card = ({
+  StyledContainer = CardContainer,
+  StyledHeader = Header,
+  StyledBody = Body,
+  StyledFooter = Footer,
+
+  containerProps,
+  headerProps,
+  bodyProps,
+  footerProps,
+  interactionFeedbackProps,
+
+  containerRef,
+  headerRef,
+  bodyRef,
+  footerRef,
+  interactiveFeedbackRef,
+
+  onPress = defaultOnPress,
+
+  header,
+  children,
+  footer,
+
+  elevation = 1,
+  feedbackType = FeedbackTypes.ripple,
+}: CardProps): JSX.Element | null => {
+  const hasHeader = Boolean(header);
+  const hasBody = Boolean(children);
+  const hasFooter = Boolean(footer);
+
+  const theme = useTheme();
+
+  return (
+    <StyledContainer
+      onPress={onPress}
+      elevation={elevation}
+      feedbackType={feedbackType}
+      theme={theme}
+      {...containerProps}
+      ref={containerRef}
+    >
+      {header && (
+        <StyledHeader
+          hasBody={hasBody}
+          hasFooter={hasFooter}
+          ref={headerRef}
+          theme={theme}
+          {...headerProps}
+        >
+          {header}
+        </StyledHeader>
+      )}
+      {children && (
+        <StyledBody
+          hasHeader={hasHeader}
+          hasFooter={hasFooter}
+          ref={bodyRef}
+          theme={theme}
+          {...bodyProps}
+        >
+          {children}
+        </StyledBody>
+      )}
+      {footer && (
+        <StyledFooter
+          hasHeader={hasHeader}
+          hasBody={hasBody}
+          ref={footerRef}
+          theme={theme}
+          {...footerProps}
+        >
+          {footer}
+        </StyledFooter>
+      )}
+    </StyledContainer>
+  );
+};
+
+Card.Header = Header;
+Card.NoPaddingHeader = NoPaddingHeader;
+Card.Footer = Footer;
+Card.Body = Body;
+Card.Container = CardContainer;
+
+export default Card;

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,0 +1,3 @@
+import Card from './Card';
+
+export default Card;

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,7 +1,8 @@
+import { Platform } from 'react-native';
 import { parseToRgb } from 'polished';
 import variants from '../enums/variants';
 import { getFontColorFromVariant } from './color';
-import Layout, { baselineWidth, defaultFontSize } from '../../constants/Layout'
+import Layout, { baselineWidth, defaultFontSize } from '../../constants/Layout';
 
 // A constant factor that works well with base 10 logarithms
 const elevationFactor = 10 ** 0.1;
@@ -43,6 +44,10 @@ export const calculateElevationValues = (elevation = 0) => {
     : calc() / 16;
   elevationValues.blur = isNegative ? (absVal * 2) / 16 : absVal * 0.25;
   elevationValues.opacity = /** isNegative ? 0.3 - 0.05 * absVal : */ 0.5 - logVal * 0.2;
+
+  elevationValues.xOffset = remToPx(elevationValues.xOffset);
+  elevationValues.yOffset = remToPx(elevationValues.yOffset);
+
   return elevationValues;
 };
 
@@ -57,12 +62,17 @@ export const getShadowStyle = (elevation = 0, shadowColor: string) => {
   if (elevation === 0) {
     return '';
   }
+
   const { red, green, blue } = parseToRgb(shadowColor);
+
+  if (elevation > 0 && Platform.OS === 'android') {
+    return `elevation: ${elevation}; shadow-color: rgb(${red},${green},${blue});`;
+  }
+
   const { xOffset, yOffset, blur, opacity } = calculateElevationValues(elevation);
 
-  return elevation > 0
-    ? `filter: drop-shadow(${xOffset}rem ${yOffset}rem ${blur}rem rgba(${red}, ${green}, ${blue},${opacity}));`
-    : `box-shadow: inset ${xOffset}rem ${yOffset}rem ${blur}rem rgba(${red}, ${green}, ${blue},${opacity});`;
+  // TODO: Add shadow inset when elevation < 0
+  return `box-shadow: ${xOffset}px ${yOffset}px ${blur}px rgba(${red},${green},${blue},${opacity});`;
 };
 
 /**

--- a/storybook/stories/Card/Card.stories.js
+++ b/storybook/stories/Card/Card.stories.js
@@ -9,7 +9,6 @@ import styled from 'styled-components';
 import { remToPx } from '../../../src/utils/styles';
 
 import colors from '../../../src/enums/colors';
-import timings from '../../../src/enums/timings';
 
 import { View } from '../../../src/baseElements';
 
@@ -47,11 +46,6 @@ storiesOf('Card', module)
       primary: 'purple',
     };
 
-    const themeTimings = {
-      ...timings,
-      xSlow: '2s',
-    };
-
     const ThemedContainer = styled.View`
       ${({ elevation = 0 }) => `
         border-radius: ${remToPx(1)}px;
@@ -87,7 +81,10 @@ storiesOf('Card', module)
         header={<Text>{text('card-themed-header', 'Card title')}</Text>}
         footer={
           <Text>
-            {text('card-themed-footer', 'Actionable buttons, whatever other stuff you want to pass in!')}
+            {text(
+              'card-themed-footer',
+              'Actionable buttons, whatever other stuff you want to pass in!',
+            )}
           </Text>
         }
         elevation={number('elevation', 0, { range: true, min: -5, max: 5, step: 1 })}

--- a/storybook/stories/Card/Card.stories.js
+++ b/storybook/stories/Card/Card.stories.js
@@ -10,7 +10,7 @@ import { remToPx } from '../../../src/utils/styles';
 
 import colors from '../../../src/enums/colors';
 
-import { View } from '../../../src/baseElements';
+import { View, Text, Button } from '../../../src/baseElements';
 
 import CenterView from '../CenterView';
 
@@ -43,28 +43,27 @@ storiesOf('Card', module)
       primary: 'purple',
     };
 
-    const ThemedContainer = styled.View`
-      ${({ elevation = 0 }) => `
-        border-radius: ${remToPx(1)}px;
-        background-color: ${themeColors.background};
+    const ThemedContainer = styled(Button)`
+      border-radius: ${remToPx(1)}px;
+      background-color: ${themeColors.background};
+      border: 1px solid ${themeColors.primary};
+    `;
 
-        transform: scale(${elevation * 0.05 + 1});
-
-        font-size: ${remToPx(1)}px;
-        border: 1px solid ${themeColors.primary};
-      `}
+    const ThemedBodyText = styled(Text)`
+      font-size: ${remToPx(1)}px;
     `;
 
     const ThemedHeader = styled(View)`
-      line-height: 0;
-      font-size: ${remToPx(4)}px;
-      padding-top: ${remToPx(2.5)}px;
       padding-left: ${remToPx(0.75)}px;
-      padding-bottom: ${remToPx(1)}px;
+    `;
+
+    const ThemedHeaderText = styled(Text)`
+      font-size: ${remToPx(4)}px;
       color: ${themeColors.primary};
     `;
 
     const ThemedFooter = styled(View)`
+      padding: ${remToPx(1)}px ${remToPx(1.5)}px;
       border-style: solid;
       border-top-width: 1px;
       border-top-color: ${themeColors.primary};
@@ -75,7 +74,7 @@ storiesOf('Card', module)
         StyledContainer={ThemedContainer}
         StyledHeader={ThemedHeader}
         StyledFooter={ThemedFooter}
-        header={text('card-themed-header', 'Card title')}
+        header={<ThemedHeaderText>{text('card-themed-header', 'Card title')}</ThemedHeaderText>}
         footer={text(
           'card-themed-footer',
           'Actionable buttons, whatever other stuff you want to pass in!',
@@ -83,10 +82,12 @@ storiesOf('Card', module)
         elevation={number('elevation', 0, { range: true, min: -5, max: 5, step: 1 })}
         onPress={action('onPress')}
       >
-        {text(
-          'card-themed-children',
-          'A Hello, World! program generally is a computer program that outputs or displays the message Hello, World!.',
-        )}
+        <ThemedBodyText>
+          {text(
+            'card-themed-children',
+            'A Hello, World! program generally is a computer program that outputs or displays the message Hello, World!.',
+          )}
+        </ThemedBodyText>
       </Card>
     );
   })

--- a/storybook/stories/Card/Card.stories.js
+++ b/storybook/stories/Card/Card.stories.js
@@ -96,7 +96,6 @@ storiesOf('Card', module)
     const cardHeaderRef = React.createRef();
     const cardBodyRef = React.createRef();
     const cardFooterRef = React.createRef();
-    const interactiveFeedbackRef = React.createRef();
     const onPress = e => {
       e.preventDefault();
       action('onPress')(
@@ -120,7 +119,6 @@ storiesOf('Card', module)
         headerRef={cardHeaderRef}
         bodyRef={cardBodyRef}
         footerRef={cardFooterRef}
-        interactiveFeedbackRef={interactiveFeedbackRef}
       >
         {text(
           'card-ref-children',

--- a/storybook/stories/Card/Card.stories.js
+++ b/storybook/stories/Card/Card.stories.js
@@ -91,7 +91,7 @@ storiesOf('Card', module)
           </Text>
         }
         elevation={number('elevation', 0, { range: true, min: -5, max: 5, step: 1 })}
-        onClick={action('onClick')}
+        onPress={action('onPress')}
       >
         <Text>
           {text(
@@ -108,9 +108,9 @@ storiesOf('Card', module)
     const cardBodyRef = React.createRef();
     const cardFooterRef = React.createRef();
     const interactiveFeedbackRef = React.createRef();
-    const onClick = e => {
+    const onPress = e => {
       e.preventDefault();
-      action('onClick')(
+      action('onPress')(
         `container width x height: ${cardContainerRef.current?.clientWidth} x ${cardContainerRef.current?.clientHeight}
           header width x height: ${cardHeaderRef.current?.clientWidth} x ${cardHeaderRef.current?.clientHeight}
           body width x height: ${cardBodyRef.current?.clientWidth} x ${cardBodyRef.current?.clientHeight}
@@ -130,7 +130,7 @@ storiesOf('Card', module)
           </Text>
         }
         elevation={number('elevation', 2, { range: true, min: -5, max: 5, step: 1 })}
-        onClick={boolean('onClick', true) ? e => onClick(e) : undefined}
+        onPress={boolean('onPress', true) ? e => onPress(e) : undefined}
         containerRef={cardContainerRef}
         headerRef={cardHeaderRef}
         bodyRef={cardBodyRef}

--- a/storybook/stories/Card/Card.stories.js
+++ b/storybook/stories/Card/Card.stories.js
@@ -98,12 +98,17 @@ storiesOf('Card', module)
     const cardFooterRef = React.createRef();
     const onPress = e => {
       e.preventDefault();
-      action('onPress')(
-        `container width x height: ${cardContainerRef.current?.clientWidth} x ${cardContainerRef.current?.clientHeight}
-          header width x height: ${cardHeaderRef.current?.clientWidth} x ${cardHeaderRef.current?.clientHeight}
-          body width x height: ${cardBodyRef.current?.clientWidth} x ${cardBodyRef.current?.clientHeight}
-          footer width x height: ${cardFooterRef.current?.clientWidth} x ${cardFooterRef.current?.clientHeight}
-          interactive width x height: ${interactiveFeedbackRef.current?.clientWidth} x ${interactiveFeedbackRef.current?.clientHeight}`,
+      cardContainerRef.current.measure((_fx, _fy, width, height, _px, _py) =>
+        action('onPress')(`container width x height: ${width} x ${height}`),
+      );
+      cardHeaderRef.current.measure((_fx, _fy, width, height, _px, _py) =>
+        action('onPress')(`header width x height: ${width} x ${height}`),
+      );
+      cardBodyRef.current.measure((_fx, _fy, width, height, _px, _py) =>
+        action('onPress')(`body width x height: ${width} x ${height}`),
+      );
+      cardFooterRef.current.measure((_fx, _fy, width, height, _px, _py) =>
+        action('onPress')(`footer width x height: ${width} x ${height}`),
       );
     };
     return (

--- a/storybook/stories/Card/Card.stories.js
+++ b/storybook/stories/Card/Card.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text } from 'react-native';
+
 import { action } from '@storybook/addon-actions';
 import { boolean, text, number } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react-native';
@@ -21,21 +21,18 @@ storiesOf('Card', module)
   .add('Default', () => {
     return (
       <Card
-        header={<Text>{text('card-header', 'Card title')}</Text>}
-        footer={
-          <Text>
-            {text('card-footer', 'Actionable buttons, whatever other stuff you want to pass in!')}
-          </Text>
-        }
+        header={text('card-header', 'Card title')}
+        footer={text(
+          'card-footer',
+          'Actionable buttons, whatever other stuff you want to pass in!',
+        )}
         elevation={number('elevation', 2, { range: true, min: -5, max: 5, step: 1 })}
         onPress={boolean('onPress', true) ? action('onPress') : undefined}
       >
-        <Text>
-          {text(
-            'card-children',
-            'A Hello, World! program generally is a computer program that outputs or displays the message Hello, World!.',
-          )}
-        </Text>
+        {text(
+          'card-children',
+          'A Hello, World! program generally is a computer program that outputs or displays the message Hello, World!.',
+        )}
       </Card>
     );
   })
@@ -78,24 +75,18 @@ storiesOf('Card', module)
         StyledContainer={ThemedContainer}
         StyledHeader={ThemedHeader}
         StyledFooter={ThemedFooter}
-        header={<Text>{text('card-themed-header', 'Card title')}</Text>}
-        footer={
-          <Text>
-            {text(
-              'card-themed-footer',
-              'Actionable buttons, whatever other stuff you want to pass in!',
-            )}
-          </Text>
-        }
+        header={text('card-themed-header', 'Card title')}
+        footer={text(
+          'card-themed-footer',
+          'Actionable buttons, whatever other stuff you want to pass in!',
+        )}
         elevation={number('elevation', 0, { range: true, min: -5, max: 5, step: 1 })}
         onPress={action('onPress')}
       >
-        <Text>
-          {text(
-            'card-themed-children',
-            'A Hello, World! program generally is a computer program that outputs or displays the message Hello, World!.',
-          )}
-        </Text>
+        {text(
+          'card-themed-children',
+          'A Hello, World! program generally is a computer program that outputs or displays the message Hello, World!.',
+        )}
       </Card>
     );
   })
@@ -117,15 +108,11 @@ storiesOf('Card', module)
     };
     return (
       <Card
-        header={<Text>{text('card-ref-header', 'View the Actions tab below')}</Text>}
-        footer={
-          <Text>
-            {text(
-              'card-ref-footer',
-              'Try adjusting the width of the viewport. New clicks will return the updated dimensions for each element.',
-            )}
-          </Text>
-        }
+        header={text('card-ref-header', 'View the Actions tab below')}
+        footer={text(
+          'card-ref-footer',
+          'Try adjusting the width of the viewport. New clicks will return the updated dimensions for each element.',
+        )}
         elevation={number('elevation', 2, { range: true, min: -5, max: 5, step: 1 })}
         onPress={boolean('onPress', true) ? e => onPress(e) : undefined}
         containerRef={cardContainerRef}
@@ -134,12 +121,10 @@ storiesOf('Card', module)
         footerRef={cardFooterRef}
         interactiveFeedbackRef={interactiveFeedbackRef}
       >
-        <Text>
-          {text(
-            'card-ref-children',
-            'Then click anywhere on the Card to see the width/height of the child elements calculated via the Ref props!',
-          )}
-        </Text>
+        {text(
+          'card-ref-children',
+          'Then click anywhere on the Card to see the width/height of the child elements calculated via the Ref props!',
+        )}
       </Card>
     );
   });

--- a/storybook/stories/Card/Card.stories.js
+++ b/storybook/stories/Card/Card.stories.js
@@ -4,6 +4,15 @@ import { action } from '@storybook/addon-actions';
 import { boolean, text, number } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react-native';
 
+import styled from 'styled-components';
+
+import { remToPx } from '../../../src/utils/styles';
+
+import colors from '../../../src/enums/colors';
+import timings from '../../../src/enums/timings';
+
+import { View } from '../../../src/baseElements';
+
 import CenterView from '../CenterView';
 
 import Card from '../../../src/components/Card';
@@ -26,6 +35,112 @@ storiesOf('Card', module)
           {text(
             'children',
             'A Hello, World! program generally is a computer program that outputs or displays the message Hello, World!.',
+          )}
+        </Text>
+      </Card>
+    );
+  })
+  .add('Themed', () => {
+    const themeColors = {
+      ...colors,
+      background: 'beige',
+      primary: 'purple',
+    };
+
+    const themeTimings = {
+      ...timings,
+      xSlow: '2s',
+    };
+
+    const ThemedContainer = styled.View`
+      ${({ elevation = 0 }) => `
+        border-radius: ${remToPx(1)}px;
+        background-color: ${themeColors.background};
+
+        transform: scale(${elevation * 0.05 + 1});
+
+        font-size: ${remToPx(1)}px;
+        border: 1px solid ${themeColors.primary};
+      `}
+    `;
+
+    const ThemedHeader = styled(View)`
+      line-height: 0;
+      font-size: ${remToPx(4)}px;
+      padding-top: ${remToPx(2.5)}px;
+      padding-left: ${remToPx(0.75)}px;
+      padding-bottom: ${remToPx(1)}px;
+      color: ${themeColors.primary};
+    `;
+
+    const ThemedFooter = styled(View)`
+      border-style: solid;
+      border-top-width: 1px;
+      border-top-color: ${themeColors.primary};
+    `;
+
+    return (
+      <Card
+        StyledContainer={ThemedContainer}
+        StyledHeader={ThemedHeader}
+        StyledFooter={ThemedFooter}
+        header={<Text>{text('header', 'Card title')}</Text>}
+        footer={
+          <Text>
+            {text('footer', 'Actionable buttons, whatever other stuff you want to pass in!')}
+          </Text>
+        }
+        elevation={number('elevation', 0, { range: true, min: -5, max: 5, step: 1 })}
+        onClick={action('onClick')}
+      >
+        <Text>
+          {text(
+            'children',
+            'A Hello, World! program generally is a computer program that outputs or displays the message Hello, World!.',
+          )}
+        </Text>
+      </Card>
+    );
+  })
+  .add('Ref', () => {
+    const cardContainerRef = React.createRef();
+    const cardHeaderRef = React.createRef();
+    const cardBodyRef = React.createRef();
+    const cardFooterRef = React.createRef();
+    const interactiveFeedbackRef = React.createRef();
+    const onClick = e => {
+      e.preventDefault();
+      action('onClick')(
+        `container width x height: ${cardContainerRef.current?.clientWidth} x ${cardContainerRef.current?.clientHeight}
+          header width x height: ${cardHeaderRef.current?.clientWidth} x ${cardHeaderRef.current?.clientHeight}
+          body width x height: ${cardBodyRef.current?.clientWidth} x ${cardBodyRef.current?.clientHeight}
+          footer width x height: ${cardFooterRef.current?.clientWidth} x ${cardFooterRef.current?.clientHeight}
+          interactive width x height: ${interactiveFeedbackRef.current?.clientWidth} x ${interactiveFeedbackRef.current?.clientHeight}`,
+      );
+    };
+    return (
+      <Card
+        header={<Text>{text('header', 'View the Actions tab below')}</Text>}
+        footer={
+          <Text>
+            {text(
+              'footer',
+              'Try adjusting the width of the viewport. New clicks will return the updated dimensions for each element.',
+            )}
+          </Text>
+        }
+        elevation={number('elevation', 2, { range: true, min: -5, max: 5, step: 1 })}
+        onClick={boolean('onClick', true) ? e => onClick(e) : undefined}
+        containerRef={cardContainerRef}
+        headerRef={cardHeaderRef}
+        bodyRef={cardBodyRef}
+        footerRef={cardFooterRef}
+        interactiveFeedbackRef={interactiveFeedbackRef}
+      >
+        <Text>
+          {text(
+            'children',
+            'Then click anywhere on the Card to see the width/height of the child elements calculated via the Ref props!',
           )}
         </Text>
       </Card>

--- a/storybook/stories/Card/Card.stories.js
+++ b/storybook/stories/Card/Card.stories.js
@@ -22,10 +22,10 @@ storiesOf('Card', module)
   .add('Default', () => {
     return (
       <Card
-        header={<Text>{text('header', 'Card title')}</Text>}
+        header={<Text>{text('card-header', 'Card title')}</Text>}
         footer={
           <Text>
-            {text('footer', 'Actionable buttons, whatever other stuff you want to pass in!')}
+            {text('card-footer', 'Actionable buttons, whatever other stuff you want to pass in!')}
           </Text>
         }
         elevation={number('elevation', 2, { range: true, min: -5, max: 5, step: 1 })}
@@ -33,7 +33,7 @@ storiesOf('Card', module)
       >
         <Text>
           {text(
-            'children',
+            'card-children',
             'A Hello, World! program generally is a computer program that outputs or displays the message Hello, World!.',
           )}
         </Text>
@@ -84,10 +84,10 @@ storiesOf('Card', module)
         StyledContainer={ThemedContainer}
         StyledHeader={ThemedHeader}
         StyledFooter={ThemedFooter}
-        header={<Text>{text('header', 'Card title')}</Text>}
+        header={<Text>{text('card-themed-header', 'Card title')}</Text>}
         footer={
           <Text>
-            {text('footer', 'Actionable buttons, whatever other stuff you want to pass in!')}
+            {text('card-themed-footer', 'Actionable buttons, whatever other stuff you want to pass in!')}
           </Text>
         }
         elevation={number('elevation', 0, { range: true, min: -5, max: 5, step: 1 })}
@@ -95,7 +95,7 @@ storiesOf('Card', module)
       >
         <Text>
           {text(
-            'children',
+            'card-themed-children',
             'A Hello, World! program generally is a computer program that outputs or displays the message Hello, World!.',
           )}
         </Text>
@@ -120,11 +120,11 @@ storiesOf('Card', module)
     };
     return (
       <Card
-        header={<Text>{text('header', 'View the Actions tab below')}</Text>}
+        header={<Text>{text('card-ref-header', 'View the Actions tab below')}</Text>}
         footer={
           <Text>
             {text(
-              'footer',
+              'card-ref-footer',
               'Try adjusting the width of the viewport. New clicks will return the updated dimensions for each element.',
             )}
           </Text>
@@ -139,7 +139,7 @@ storiesOf('Card', module)
       >
         <Text>
           {text(
-            'children',
+            'card-ref-children',
             'Then click anywhere on the Card to see the width/height of the child elements calculated via the Ref props!',
           )}
         </Text>

--- a/storybook/stories/Card/Card.stories.js
+++ b/storybook/stories/Card/Card.stories.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { action } from '@storybook/addon-actions';
+import { boolean, text, number } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react-native';
+
+import CenterView from '../CenterView';
+
+import Card from '../../../src/components/Card';
+
+storiesOf('Card', module)
+  .addDecorator(getStory => <CenterView>{getStory()}</CenterView>)
+  .add('Default', () => {
+    return (
+      <Card
+        header={<Text>{text('header', 'Card title')}</Text>}
+        footer={
+          <Text>
+            {text('footer', 'Actionable buttons, whatever other stuff you want to pass in!')}
+          </Text>
+        }
+        elevation={number('elevation', 2, { range: true, min: -5, max: 5, step: 1 })}
+        onPress={boolean('onPress', true) ? action('onPress') : undefined}
+      >
+        <Text>
+          {text(
+            'children',
+            'A Hello, World! program generally is a computer program that outputs or displays the message Hello, World!.',
+          )}
+        </Text>
+      </Card>
+    );
+  });

--- a/storybook/stories/index.js
+++ b/storybook/stories/index.js
@@ -1,3 +1,4 @@
 import './Button/Button.stories';
+import './Card/Card.stories';
 import './StorybookButton/Button.stories';
 import './Welcome/Welcome.stories';


### PR DESCRIPTION
Ports the Card component along with the 3 storybook stories (default, themed, and ref).

For the shadow, the Card uses the native `elevation` prop for Android and styled-component's `box-shadow` for iOS/other. Unfortunately, there's no standard way to set a negative elevation using inset shadows, but there are a few interesting workarounds:

- https://github.com/facebook/react-native/issues/2255
- https://stackoverflow.com/questions/38084120/box-shadowinset-for-react-native
- https://www.npmjs.com/package/react-native-inset-shadow

This PR only supports an elevation of 0 or greater.

The `InteractionFeedback` component and its related props were left out, and the feedback animation was replaced through react-native's `Pressable` component. This component provides a configurable ripple effect for Android, which this PR takes advantage of. iOS/other may require the use of another component (e.g., `TouchableOpacity`) for feedback, as `Pressable` alone does not seem to provide any.

I look forward to your thoughts!
