### PR TITLE
Add PR comment with `actions/github-script`

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -18,8 +18,12 @@ jobs:
           expo-packager: yarn
       - run: yarn install
       - run: expo publish --release-channel=pr-${{ github.event.number }}
-      - uses: unsplash/comment-on-pr@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/github-script@v4
         with:
-          msg: App is ready for review, you can [see it here](https://exp.host/@${{ secrets.EXPO_CLI_USERNAME }}/foundry-native-ui?release-channel=pr-${{ github.event.number }}).
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'App is ready for review, you can [see it here](https://exp.host/@${{ secrets.EXPO_CLI_USERNAME }}/foundry-native-ui?release-channel=pr-${{ github.event.number }}).'
+            })


### PR DESCRIPTION
Replaces the steps to add a comment to a PR with a [GitHub script](https://github.com/actions/github-script#comment-on-an-issue). This has been tested with [a PR on my fork](https://github.com/dawsonbooth/foundry-native-ui/pull/2).

I do not expect it to work for this PR itself, since GitHub likes to use the existing workflow instead of the new one when it comes to using the `pull_request_target` event.