### PR TITLE
#9 Add community material design icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^12.0.0",
+    "@mdi/js": "^5.9.55",
     "@react-native-community/masked-view": "0.1.10",
     "@react-navigation/bottom-tabs": "5.11.2",
     "@react-navigation/native": "~5.8.10",
@@ -47,6 +48,7 @@
     "react-native-reanimated": "~2.1.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.0.0",
+    "react-native-svg": "^12.1.1",
     "react-native-web": "~0.13.12",
     "react-spring": "^9.2.3"
   },

--- a/src/baseElements/index.tsx
+++ b/src/baseElements/index.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components/native';
-// import { animated } from 'react-spring';
+import { Animated } from 'react-native';
 import { withGlobalStyle } from '../context';
 
 // Use these elements over native styled.xx elements, as they apply
@@ -7,14 +7,14 @@ import { withGlobalStyle } from '../context';
 export const View = withGlobalStyle(styled.View``);
 export const Text = withGlobalStyle(styled.Text``);
 export const Button = withGlobalStyle(styled.Pressable``); // TODO: investigate the accessibility impacts of this
-/* export const Input = withGlobalStyle(styledHtml.input``);
-export const Label = withGlobalStyle(styledHtml.label``);
-export const HR = withGlobalStyle(styledHtml.hr``);
-export const Table = withGlobalStyle(styledHtml.table``);
-export const TH = withGlobalStyle(styledHtml.th``);
-export const TD = withGlobalStyle(styledHtml.td``);
-export const TR = withGlobalStyle(styledHtml.tr``);
-export const TextArea = withGlobalStyle(styledHtml.textarea``);
+// export const Input = withGlobalStyle(styledHtml.input``);
+// export const Label = withGlobalStyle(styledHtml.label``);
+// export const HR = withGlobalStyle(styledHtml.hr``);
+// export const Table = withGlobalStyle(styledHtml.table``);
+// export const TH = withGlobalStyle(styledHtml.th``);
+// export const TD = withGlobalStyle(styledHtml.td``);
+// export const TR = withGlobalStyle(styledHtml.tr``);
+// export const TextArea = withGlobalStyle(styledHtml.textarea``);
 
-export const AnimatedDiv = withGlobalStyle(styled(animated.div)``);
-export const AnimatedSpan = withGlobalStyle(styled(animated.span)``); */
+export const AnimatedView = withGlobalStyle(styled(Animated.View)``);
+// export const AnimatedSpan = withGlobalStyle(styled(animated.span)``);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -24,6 +24,7 @@ import { getShadowStyle } from '../../utils/styles';
 // import { InteractionFeedbackProps } from '../InteractionFeedback/InteractionFeedback';
 import FeedbackTypes from '../../enums/feedbackTypes';
 import UnstyledIcon from '../Icon';
+import { mdiLoading } from '@mdi/js';
 
 export type ButtonContainerProps = {
   theme: FoundryContextType;
@@ -193,14 +194,14 @@ const Button = ({
         iconPrefix &&
         (typeof iconPrefix === 'string' && iconPrefix !== '' ? (
           <StyledLeftIconContainer hasContent={hasContent} ref={leftIconContainerRef}>
-            <UnstyledIcon name={iconPrefix} size={remToPx(1, scale)} />
+            <UnstyledIcon path={iconPrefix} size={`${remToPx(1, scale)}px`} />
           </StyledLeftIconContainer>
         ) : (
           <StyledLeftIconContainer ref={leftIconContainerRef}>{iconPrefix}</StyledLeftIconContainer>
         ))}
       {isProcessing && (
         <StyledLeftIconContainer hasContent={hasContent} ref={leftIconContainerRef}>
-          <UnstyledIcon name="loading" size={remToPx(1, scale)} spin={1} />
+          <UnstyledIcon path={mdiLoading} size={`${remToPx(1, scale)}px`} spin={1} />
         </StyledLeftIconContainer>
       )}
       {/* // TODO: make Text an exported subcomponent */}
@@ -208,7 +209,7 @@ const Button = ({
       {iconSuffix &&
         (typeof iconSuffix === 'string' ? (
           <StyledRightIconContainer hasContent={hasContent} ref={rightIconContainerRef}>
-            <UnstyledIcon name={iconSuffix} size={remToPx(1, scale)} />
+            <UnstyledIcon path={iconSuffix} size={`${remToPx(1, scale)}px`} />
           </StyledRightIconContainer>
         ) : (
           <StyledRightIconContainer hasContent={hasContent} ref={rightIconContainerRef}>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -23,6 +23,7 @@ import { getShadowStyle } from '../../utils/styles';
 // import InteractionFeedback from '../InteractionFeedback';
 // import { InteractionFeedbackProps } from '../InteractionFeedback/InteractionFeedback';
 import FeedbackTypes from '../../enums/feedbackTypes';
+import UnstyledIcon from '../Icon';
 
 export type ButtonContainerProps = {
   theme: FoundryContextType;
@@ -103,27 +104,27 @@ export const ButtonContainer: string & StyledComponentBase<any, {}, ButtonContai
   margin-bottom: -5px;
 `; */
 
-/* const IconContainer = styled(Div)`
-  height: 1rem;
-  vertical-align: middle;
-`; */
+const IconContainer = styled(View)`
+  height: ${remToPx(1)}px;
+  /* vertical-align: middle; */
+`;
 
-/* const LeftIconContainer = styled(IconContainer)`
+const LeftIconContainer = styled(IconContainer)`
   ${({ hasContent }: { hasContent: boolean }) => `
-    ${hasContent ? 'margin-right: 0.75em;' : ''}
+    ${hasContent ? `margin-right: ${remToPx(0.75)}px;` : ''}
   `}
 `;
 
 const RightIconContainer = styled(IconContainer)`
   ${({ hasContent }: { hasContent: boolean }) => `
-    ${hasContent ? 'margin-left: 0.75em;' : ''}
+    ${hasContent ? `margin-left: ${remToPx(0.75)}px;` : ''}
   `}
-`; */
+`;
 
 const Button = ({
   StyledContainer = ButtonContainer,
-  // StyledLeftIconContainer = LeftIconContainer,
-  // StyledRightIconContainer = RightIconContainer,
+  StyledLeftIconContainer = LeftIconContainer,
+  StyledRightIconContainer = RightIconContainer,
   containerProps = {},
   iconPrefix,
   iconSuffix,
@@ -181,37 +182,39 @@ const Button = ({
     ...containerProps,
   };
 
+  const { colors, scale } = theme;
+
   const buttonContent = isLoading ? (
     // <LoadingBar ref={loadingBarRef} />
     <View />
   ) : (
     <>
-      {/* {!isProcessing &&
+      {!isProcessing &&
         iconPrefix &&
         (typeof iconPrefix === 'string' && iconPrefix !== '' ? (
           <StyledLeftIconContainer hasContent={hasContent} ref={leftIconContainerRef}>
-            <UnstyledIcon path={iconPrefix} size="1rem" />
+            <UnstyledIcon name={iconPrefix} size={remToPx(1, scale)} />
           </StyledLeftIconContainer>
         ) : (
           <StyledLeftIconContainer ref={leftIconContainerRef}>{iconPrefix}</StyledLeftIconContainer>
         ))}
       {isProcessing && (
         <StyledLeftIconContainer hasContent={hasContent} ref={leftIconContainerRef}>
-          <UnstyledIcon path={mdiLoading} size="1rem" spin={1} />
+          <UnstyledIcon name="loading" size={remToPx(1, scale)} spin={1} />
         </StyledLeftIconContainer>
-      )} */}
+      )}
       {/* // TODO: make Text an exported subcomponent */}
       <Text style={{ color: fontColor }}>{children}</Text>
-      {/* {iconSuffix &&
+      {iconSuffix &&
         (typeof iconSuffix === 'string' ? (
           <StyledRightIconContainer hasContent={hasContent} ref={rightIconContainerRef}>
-            <UnstyledIcon path={iconSuffix} size="1rem" />
+            <UnstyledIcon name={iconSuffix} size={remToPx(1, scale)} />
           </StyledRightIconContainer>
         ) : (
           <StyledRightIconContainer hasContent={hasContent} ref={rightIconContainerRef}>
             {iconSuffix}
           </StyledRightIconContainer>
-        ))} */}
+        ))}
     </>
   );
 
@@ -225,7 +228,7 @@ const Button = ({
 Button.Container = ButtonContainer;
 Button.ButtonTypes = ButtonTypes;
 // Button.LoadingBar = StyledProgress;
-// Button.LeftIconContainer = LeftIconContainer;
-// Button.RightIconContainer = RightIconContainer;
+Button.LeftIconContainer = LeftIconContainer;
+Button.RightIconContainer = RightIconContainer;
 
 export default Button;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -76,11 +76,24 @@ export const ButtonContainer: string & StyledComponentBase<any, {}, ButtonContai
 )`
   ${({ theme, disabled, elevation = 0, color, variant, feedbackType }: ButtonContainerProps) => {
     const { colors, scale } = theme;
-    const backgroundColor = getBackgroundColorFromVariant(variant, color, colors.transparent, disabled);
-    const fontColor = getFontColorFromVariant(variant, color, colors.background, colors.grayDark, disabled);
+    const backgroundColor = getBackgroundColorFromVariant(
+      variant,
+      color,
+      colors.transparent,
+      disabled,
+    );
+    const fontColor = getFontColorFromVariant(
+      variant,
+      color,
+      colors.background,
+      colors.grayDark,
+      disabled,
+    );
 
     return `
       display: flex;
+      flex-direction: row;
+      align-items: center;
       position: relative;
       font-size: ${remToPx(1, scale)}px;
       padding: ${remToPx(0.75, scale)}px ${remToPx(1, scale)}px;
@@ -90,7 +103,6 @@ export const ButtonContainer: string & StyledComponentBase<any, {}, ButtonContai
       border-width: 0px;
       color: ${fontColor};
       background-color: ${backgroundColor} !important;
-      align-items: center;
       &:hover {
         background-color: darkred;
       }
@@ -107,7 +119,6 @@ export const ButtonContainer: string & StyledComponentBase<any, {}, ButtonContai
 
 const IconContainer = styled(View)`
   height: ${remToPx(1)}px;
-  /* vertical-align: middle; */
 `;
 
 const LeftIconContainer = styled(IconContainer)`

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PressableAndroidRippleConfig, Rect } from 'react-native';
+import { LayoutChangeEvent, PressableAndroidRippleConfig, Rect } from 'react-native';
 // import UnstyledIcon from '@mdi/react';
 // import { mdiLoading } from '@mdi/js';
 import styled, { StyledComponentBase } from 'styled-components/native';
@@ -170,9 +170,17 @@ const Button = ({
     theme.colors.background,
     theme.colors.grayDark,
   );
+  const [rippleRadius, setRippleRadius] = React.useState(60);
+
+  const handleLayoutChange = (event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+
+    setRippleRadius(Math.max(width, height) / 2);
+  };
+
   const rippleConfig = {
     color: fontColor,
-    radius: 60,
+    radius: rippleRadius,
     ...android_ripple,
   };
 
@@ -183,6 +191,7 @@ const Button = ({
     onPress,
     onMouseDown,
     onMouseUp,
+    onLayout: handleLayoutChange,
     elevation,
     color: containerColor,
     variant,

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { Animated, Easing } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
 
+import { AnimatedView } from '../../baseElements';
+
 interface SVGIconProps {
   path: string;
   size: number | string;
@@ -47,9 +49,9 @@ const Icon: React.FC<IconProps> = ({ path, size, color = 'white', spin = false }
   });
 
   return (
-    <Animated.View style={[{ transform: [{ rotate: interpolatedSpinAnim }] }]}>
+    <AnimatedView style={[{ transform: [{ rotate: interpolatedSpinAnim }] }]}>
       {iconElement}
-    </Animated.View>
+    </AnimatedView>
   );
 };
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,17 +1,30 @@
 import * as React from 'react';
 import { Animated, Easing } from 'react-native';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
+import Svg, { Path } from 'react-native-svg';
+
+interface SVGIconProps {
+  path: string;
+  size: number | string;
+  color?: string;
+}
+
+const SVGIcon: React.FC<SVGIconProps> = ({ path, size, color = 'white' }) => {
+  return (
+    <Svg height={size} width={size} viewBox="0 0 24 24">
+      <Path fill={color} d={path} />
+    </Svg>
+  );
+};
 
 interface IconProps {
-  name: string;
-  size: number;
+  path: string;
+  size: number | string;
   color?: string;
   spin?: boolean | number;
 }
 
-const Icon: React.FC<IconProps> = ({ name, size, color = 'white', spin = false }) => {
-  // @ts-expect-error
-  const iconElement = <MaterialCommunityIcons name={name} size={size} color={color} />;
+const Icon: React.FC<IconProps> = ({ path, size, color = 'white', spin = false }) => {
+  const iconElement = <SVGIcon path={path} size={size} color={color} />;
 
   if (!spin) return iconElement;
 
@@ -25,7 +38,7 @@ const Icon: React.FC<IconProps> = ({ name, size, color = 'white', spin = false }
         easing: Easing.linear,
         useNativeDriver: true,
       }),
-    ).start(console.log);
+    ).start();
   }, [spinAnim]);
 
   const interpolatedSpinAnim = spinAnim.interpolate({

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { Animated, Easing } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+
+interface IconProps {
+  name: string;
+  size: number;
+  color?: string;
+  spin?: boolean | number;
+}
+
+const Icon: React.FC<IconProps> = ({ name, size, color = 'white', spin = false }) => {
+  // @ts-expect-error
+  const iconElement = <MaterialCommunityIcons name={name} size={size} color={color} />;
+
+  if (!spin) return iconElement;
+
+  const spinAnim = React.useRef(new Animated.Value(0)).current;
+
+  React.useEffect(() => {
+    Animated.loop(
+      Animated.timing(spinAnim, {
+        toValue: 100,
+        duration: Number(spin) * 1000,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      }),
+    ).start(console.log);
+  }, [spinAnim]);
+
+  const interpolatedSpinAnim = spinAnim.interpolate({
+    inputRange: [0, 100],
+    outputRange: ['0deg', '360deg'],
+  });
+
+  return (
+    <Animated.View style={[{ transform: [{ rotate: interpolatedSpinAnim }] }]}>
+      {iconElement}
+    </Animated.View>
+  );
+};
+
+export default Icon;

--- a/src/components/Icon/index.ts
+++ b/src/components/Icon/index.ts
@@ -1,0 +1,3 @@
+import Icon from './Icon';
+
+export default Icon;

--- a/storybook/stories/Button/Button.stories.js
+++ b/storybook/stories/Button/Button.stories.js
@@ -20,7 +20,7 @@ storiesOf('Button', module)
       disabled={boolean('disabled', false)}
       iconPrefix={mdiMessage}
       iconSuffix={mdiSend}
-      isProcessing
+      isProcessing={boolean('isProcessing', false)}
     >
       <Text>{text('children', 'Default text')}</Text>
     </Button>

--- a/storybook/stories/Button/Button.stories.js
+++ b/storybook/stories/Button/Button.stories.js
@@ -17,6 +17,9 @@ storiesOf('Button', module)
       color={color('color', colors.primaryDark)}
       onPress={action('button-press')}
       disabled={boolean('disabled', false)}
+      iconPrefix="message"
+      iconSuffix="send"
+      isProcessing
     >
       <Text>{text('children', 'Default text')}</Text>
     </Button>

--- a/storybook/stories/Button/Button.stories.js
+++ b/storybook/stories/Button/Button.stories.js
@@ -8,6 +8,7 @@ import colors from '../../../src/enums/colors';
 import variants from '../../../src/enums/variants';
 import Button from '../../../src/components/Button';
 import CenterView from '../CenterView';
+import { mdiMessage, mdiSend } from '@mdi/js';
 
 storiesOf('Button', module)
   .addDecorator(getStory => <CenterView>{getStory()}</CenterView>)
@@ -17,8 +18,8 @@ storiesOf('Button', module)
       color={color('color', colors.primaryDark)}
       onPress={action('button-press')}
       disabled={boolean('disabled', false)}
-      iconPrefix="message"
-      iconSuffix="send"
+      iconPrefix={mdiMessage}
+      iconSuffix={mdiSend}
       isProcessing
     >
       <Text>{text('children', 'Default text')}</Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,6 +2147,11 @@
     "@babel/runtime" "^7.7.2"
     regenerator-runtime "^0.13.3"
 
+"@mdi/js@^5.9.55":
+  version "5.9.55"
+  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-5.9.55.tgz#8f5bc4d924c23f30dab20545ddc768e778bbc882"
+  integrity sha512-BbeHMgeK2/vjdJIRnx12wvQ6s8xAYfvMmEAVsUx9b+7GiQGQ9Za8jpwp17dMKr9CgKRvemlAM4S7S3QOtEbp4A==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -5383,7 +5388,7 @@ css-loader@^3.0.0:
     schema-utils "^2.7.0"
     semver "^6.3.0"
 
-css-select@^2.0.2:
+css-select@^2.0.2, css-select@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-2.1.0.tgz#6a34653356635934a81baca68d0255432105dbef"
   integrity sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==
@@ -5410,6 +5415,14 @@ css-to-react-native@^3.0.0:
     camelize "^1.0.0"
     css-color-keywords "^1.0.0"
     postcss-value-parser "^4.0.2"
+
+css-tree@^1.0.0-alpha.39:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
+  integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
+  dependencies:
+    mdn-data "2.0.14"
+    source-map "^0.6.1"
 
 css-what@^3.2.1:
   version "3.4.2"
@@ -9072,6 +9085,11 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+mdn-data@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -11010,6 +11028,14 @@ react-native-screens@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.0.0.tgz#ee4c2d69abf7411603868b57214feec5e8f637fa"
   integrity sha512-35II5oxTaVp3OP8y0eLPOPpQkxG4fRKQ+dL1YSE1we5kCZFOU0l/Rn0T79HbyUu1LPwUZr6lZupPs0ULnRyMuQ==
+
+react-native-svg@^12.1.1:
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-12.1.1.tgz#5f292410b8bcc07bbc52b2da7ceb22caf5bcaaee"
+  integrity sha512-NIAJ8jCnXGCqGWXkkJ1GTzO4a3Md5at5sagYV8Vh4MXYnL4z5Rh428Wahjhh+LIjx40EE5xM5YtwyJBqOIba2Q==
+  dependencies:
+    css-select "^2.1.0"
+    css-tree "^1.0.0-alpha.39"
 
 react-native-swipe-gestures@^1.0.4:
   version "1.0.5"
@@ -13087,8 +13113,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
- Adds an icon component that is similar to that of [`@mdi/react`](https://github.com/Templarian/MaterialDesign-React)
- Takes in and renders any SVG path through the `path` prop
- Uses `Animated` to optionally spin the icons with a duration (useful for `isProcessing`)